### PR TITLE
Removed -Ofast due to backward compatibility issues

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Removed -Ofast optimization due to compatibility issues.
+
 
 1.000     2020-08-20
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name = PDF-API2-XS
 author = Rob Scovell <robscovell@48hc.com>
 license = LGPL_2_1
 copyright_holder = Steve Simms
-version = 1.000
+version = 1.001
 abstract = Optional PDF::API2 add-on using XS to speed up expensive operations
 
 [MetaResources]

--- a/dist.ini
+++ b/dist.ini
@@ -31,7 +31,6 @@ except = \.perlcriticrc
 
 [MakeMaker::Awesome]
 WriteMakefile_arg = CCFLAGS => '-Wall -std=c99'
-WriteMakefile_arg = OPTIMIZE => '-Ofast'
 WriteMakefile_arg = XSMULTI => 1
 
 [MetaYAML]


### PR DESCRIPTION
-Ofast is a nonstandard optimisation level which has caused some issues with CPAN testing in some versions of Linux.