### PR TITLE
Declare @ISA and @EXPORT as ours

### DIFF
--- a/lib/PDF/API2/XS/ImagePNG.pm
+++ b/lib/PDF/API2/XS/ImagePNG.pm
@@ -8,8 +8,8 @@ use warnings;
 require XSLoader;
 require Exporter;
 
-@ISA = qw(Exporter);
-@EXPORT = qw(split_channels unfilter);
+our @ISA = qw(Exporter);
+our @EXPORT = qw(split_channels unfilter);
 
 XSLoader::load();
 


### PR DESCRIPTION
Using perl 5.16, this module would not compile because:

Global symbol "@ISA" requires explicit package name at lib/x86_64-linux-thread-multi/PDF/API2/XS/ImagePNG.pm line 11.
Global symbol "@EXPORT" requires explicit package name at lib/x86_64-linux-thread-multi/PDF/API2/XS/ImagePNG.pm line 12.

Declaring them as our @ISA and our @EXPORT solved that problem